### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,0 +1,12 @@
+FROM postgres:latest
+
+# Set environment variables
+ENV POSTGRES_USER=${POSTGRES_USER}
+ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+ENV POSTGRES_DB=${POSTGRES_DB}
+
+# Expose the default postgres port
+EXPOSE 5432
+
+# Set the default command for the container to run postgres
+CMD ["postgres"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO strapi-docker-compose
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,48 @@
+namespace: strapi-docker-compose
+
+db:
+  defines: runnable
+  metadata:
+    name: db
+    description: PostgreSQL database used by the Strapi CMS.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    db:
+      image: env-3551.registry.local/db:main-e44ba9a
+      build: .
+      dockerfile: Dockerfile.db
+  services:
+    postgres-default:
+      description: Default PostgreSQL port for database connections
+      container: db
+      port: 5432
+      host-port: 5432
+      publish: true
+      protocol: tcp
+  connections:
+    database-to-strapi:
+      target: strapi-docker-compose/strapi
+      service: postgres-default
+      optional: true
+      description: PostgreSQL database connection to Strapi CMS
+  variables:
+    postgres-user:
+      env: POSTGRES_USER
+      type: string
+      value: strapiuser
+      description: Username for PostgreSQL database
+    postgres-password:
+      env: POSTGRES_PASSWORD
+      type: string
+      value: strapiPass123
+      description: Password for PostgreSQL database
+    postgres-db:
+      env: POSTGRES_DB
+      type: string
+      value: strapidb
+      description: Database name for PostgreSQL
+
+stack:
+  defines: group
+  members:
+    - strapi-docker-compose/db


### PR DESCRIPTION
# Containerization and Deployment Configuration

## Summary of Changes
I've worked on containerizing the application and writing deployment configuration for a Strapi CMS application with a PostgreSQL database. Below are the key changes and configurations I've made:

- **Docker Compose Services Mapped**: The `docker-compose.yml` file has been analyzed, and it confirms the presence of two services: `strapi` (Strapi CMS instance) and `db` (PostgreSQL database). The `strapi` service is exposed on port 1337 and depends on the `db` service.

- **Database Dockerfile**: A new `Dockerfile.db` has been created for the PostgreSQL database service. This Dockerfile sets the necessary environment variables and exposes the default PostgreSQL port (5432).

- **Monk.io Configuration**: Added `monk.yaml` and `MANIFEST` files for Monk.io configuration, which will help in the deployment process.

## Configuration Details
- The `docker-compose.yml` file includes environment variables for the `db` service: `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`.
- The `Dockerfile.db` confirms these variables and exposes port 5432, which is the standard port for PostgreSQL.
- The `db` service is configured to connect to the `strapi` service, ensuring proper communication between the database and the CMS.

## Instructions for Continuation
- **Strapi Service Code**: The Strapi service code was not found in the repository. To complete the containerization of the Strapi service, the application code needs to be located and a Dockerfile must be created accordingly.
- **Merge PR**: Once the PR is merged, the application will be re-deployed on each subsequent push, assuming the Strapi service code is resolved.

## Final Notes
The containerization and deployment configuration are set up for the PostgreSQL database. However, the Strapi CMS application's code is missing from the repository, which prevents the creation of a Dockerfile for the `strapi` service. To move forward, the application code needs to be provided or located within the repository. Once that is addressed, a Dockerfile for the `strapi` service can be created, and the containerization process will be complete.